### PR TITLE
Fix access control and SQL injection

### DIFF
--- a/del.php
+++ b/del.php
@@ -1,22 +1,23 @@
 <?php
-session_start();
-include("connect.php");
-if(!isset($_SESSION['username'])) {
-header("location: index.php);
-} 
-if(isset($_GET['id'])) {
-$id = $_GET['id'];
- 
-$sql = "DELETE FROM posts WHERE id = '$id'";
- 
-$result = mysqli_query($dbcon, $sql);
-if($result) {
-header('location: index.php');
-}
-else {
-	echo "Failed to delete.".mysqli_connect_error();
-}
-}
-mysqli_close($dbcon);
+  session_start();
+  include("connect.php");
+
+  if(!isset($_SESSION['username'])) {
+    header("location: index.php");
+    exit();
+  }
+
+  if(isset($_GET['id'])) {
+    $id = mysqli_real_escape_string($dbcon, $_GET['id']);
+    $sql = "DELETE FROM posts WHERE id = '$id'";
+    $result = mysqli_query($dbcon, $sql);
+
+    if($result) {
+      header('location: index.php');
+    } else {
+      echo "Failed to delete.".mysqli_connect_error();
+    }
+  }
+  mysqli_close($dbcon);
 ?>
- 
+


### PR DESCRIPTION
In `del.php`, the script doesn't make a call to `exit` after setting the `Location` header allowing for unauthenticated users to either delete posts or attack the database using the SQL injection. This pull request fixes both issues by adding a call to `exit` after call to `header` and by using `mysqli_real_escape_string` to cleanse the `id` input.